### PR TITLE
fix: 💚 release build for versioning

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   bundle-size:
-    name: "Audit the bundle size"
+    name: Audit the bundle size
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -5,7 +5,7 @@ name: Audit
 # - [ ] dead css checks
 # - [ ] coverage drops
 
-on:
+on: # yamllint disable-line rule:truthy
   pull_request:
     types:
       - synchronize

--- a/.github/workflows/bookkeeping-issues.yml
+++ b/.github/workflows/bookkeeping-issues.yml
@@ -7,7 +7,7 @@ name: Issues Bookkeeping
 # - [ ] cleans up language
 # - [ ] checks that template is filled out
 
-on:
+on: # yamllint disable-line rule:truthy
   issues:
     types:
       - opened

--- a/.github/workflows/bookkeeping-prs.yml
+++ b/.github/workflows/bookkeeping-prs.yml
@@ -7,7 +7,7 @@ name: PR Bookkeeping
 # - [ ] cleans up language
 # - [ ] checks that template is filled out
 
-on:
+on: # yamllint disable-line rule:truthy
   pull_request:
     types:
       - opened

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,4 +26,3 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deploy-github-pages.outputs.page_url }}
-

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,6 @@
 name: Deploy
 
-on:
+on: # yamllint disable-line rule:truthy
   push:
     branches:
       - main

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,6 +1,6 @@
 name: Greetings
 
-on:
+on: # yamllint disable-line rule:truthy
   - pull_request
   - issues
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -78,7 +78,7 @@ jobs:
           VALIDATE_TYPESCRIPT_PRETTIER: true
           VALIDATE_YAML: true # turning on for now while prettier is broken
           # VALIDATE_YAML_PRETTIER: true => turning it off because its writing 4 spaces instead of 2
-          YAML_CONFIG_FILE: ".yamllint.yml"
+          YAML_CONFIG_FILE: "yamllint.config.yml"
 
       - uses: stefanzweifel/git-auto-commit-action@v5
         name: Commit and push linting fixes

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Lint
 
-on:
+on: # yamllint disable-line rule:truthy
   - push
   - pull_request
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,7 +51,7 @@ jobs:
           FIX_TSX: true
           FIX_TYPESCRIPT_PRETTIER: true
           # FIX_YAML_PRETTIER: true => turning this off til i figure out why its not respecting config
-          # GITHUB_ACTIONS_CONFIG_FILE: "actionlint.yml"
+          # GITHUB_ACTIONS_CONFIG_FILE: "actionlint.yml" => basically unneeded
           # GITLEAKS_CONFIG: ".gitleaks.toml" # Path to your Gitleaks config if you have one
           JAVASCRIPT_ES_CONFIG_FILE: "eslint.config.js"
           # MARKDOWN_CONFIG_FILE: ".markdown-lint.yml"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -78,6 +78,7 @@ jobs:
           VALIDATE_TYPESCRIPT_PRETTIER: true
           VALIDATE_YAML: true # turning on for now while prettier is broken
           # VALIDATE_YAML_PRETTIER: true => turning it off because its writing 4 spaces instead of 2
+          YAML_CONFIG_FILE: ".yamllint.yml"
 
       - uses: stefanzweifel/git-auto-commit-action@v5
         name: Commit and push linting fixes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,6 @@ jobs:
 
       - run: npm ci
         name: Install dependencies
-      - run: npm ci
 
       - run: npm publish
         name: Publish to GitHub Packages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,6 @@
 name: Publish
 
-on:
+on: # yamllint disable-line rule:truthy
   release:
     types:
       - created

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: Release
 
-on:
+on: # yamllint disable-line rule:truthy
   push:
     branches:
       - main

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,6 +1,6 @@
 name: Review
 
-on:
+on: # yamllint disable-line rule:truthy
   - push
   - pull_request
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,6 @@
 name: Stale
 
-on:
+on: # yamllint disable-line rule:truthy
   schedule:
     - cron: "30 1 * * *"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on:
+on: # yamllint disable-line rule:truthy
   - push
 
 jobs:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -3,7 +3,7 @@ name: Version
 # @TODO: check if this could replace changesets
 # if so, i can get rid of the publish command and changesets
 
-on:
+on: # yamllint disable-line rule:truthy
   push:
     branches:
       - main
@@ -25,7 +25,7 @@ jobs:
           #  the workflow run. For example, `main` or `1.x`
           target-branch: ${{ github.ref_name }}
 
-      # # The logic below handles the npm publication:
+      # The logic below handles the npm publication:
       # - uses: actions/checkout@v4
       #   name: Checkout repository
       #   # these if statements ensure that a publication only occurs when

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,57 @@
+name: Version
+
+# @TODO: check if this could replace changesets
+# if so, i can get rid of the publish command and changesets
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    name: Version using Semantic Versioning
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          release-type: node
+          # The short ref name of the branch or tag that triggered
+          #  the workflow run. For example, `main` or `1.x`
+          target-branch: ${{ github.ref_name }}
+
+      # # The logic below handles the npm publication:
+      # - uses: actions/checkout@v4
+      #   name: Checkout repository
+      #   # these if statements ensure that a publication only occurs when
+      #   # a new release is created:
+      #   if: ${{ steps.release.outputs.release_created }}
+
+      # - uses: actions/setup-node@v4
+      #   name: Setup Node.js @v20
+      #   if: ${{ steps.release.outputs.release_created }}
+      #   with:
+      #     cache: npm
+      #     node-version: 20.x
+      #     registry-url: 'https://registry.npmjs.org'
+
+      # - run: npm ci
+      #   name: Install dependencies
+      #   if: ${{ steps.release.outputs.release_created }}
+
+      # - run: npm publish
+      #   name: Publish to NPM
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+      #   if: ${{ steps.release.outputs.release_created }}
+
+      # - run: npm publish
+      #   name: Publish to GitHub Packages
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      #   if: ${{ steps.release.outputs.release_created }}

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -12,4 +12,7 @@ rules:
     ignore: |
       .github/*.yml
 
+  indentation:
+    spaces: 2
+
   line-length: disable

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -10,5 +10,6 @@ rules:
 
   document-start:
     ignore: |
-      /.github/*.yml
+      .github/*.yml
 
+  line-length: disable

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,14 @@
+---
+
+extends: default
+
+rules:
+  comments:
+    min-spaces-from-content: 1
+
+  comments-indentation: disable
+
+  document-start:
+    ignore: |
+      /.github/*.yml
+

--- a/yamllint.config.yml
+++ b/yamllint.config.yml
@@ -14,5 +14,6 @@ rules:
 
   indentation:
     spaces: consistent
+    indent-sequences: consistent
 
   line-length: disable

--- a/yamllint.config.yml
+++ b/yamllint.config.yml
@@ -5,8 +5,9 @@ extends: default
 rules:
   comments:
     min-spaces-from-content: 1
+    require-starting-space: true
 
-  comments-indentation: disable
+  comments-indentation: {}
 
   document-start:
     ignore: |

--- a/yamllint.config.yml
+++ b/yamllint.config.yml
@@ -13,6 +13,6 @@ rules:
       .github/*.yml
 
   indentation:
-    spaces: 2
+    spaces: consistent
 
   line-length: disable


### PR DESCRIPTION
## Description

Right now the release GitHub Action is breaking because it's looking for a `changesets` file that won't be needed for this simple release.  I want a simpler versioning of this repo.

## Screenshots

<!-- If applicable, add screenshots to help explain your problem -->

## Checklist

<!-- Have you considered all of the following? -->

Please confirm by checking off each item to ensure you've considered it:

- [x] Did you create or update tests?
- [x] Did you create or update any documentation?
- [x] Did you export all new members of the lib?

## Additional context

N/A

---

Fixes: N/A
